### PR TITLE
docs: fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F680 Feature request"
 about: Suggest a feature for this Library
-label: enhancement
+labels: enhancement
 ---
 
 <!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

--- a/.github/ISSUE_TEMPLATE/3-docs-bug.md
+++ b/.github/ISSUE_TEMPLATE/3-docs-bug.md
@@ -1,7 +1,7 @@
 ---
 name: '📚 Docs or demo app issue report'
 about: Report an issue in documentation or demo application
-label: documentation
+labels: documentation
 ---
 
 <!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅

--- a/.github/ISSUE_TEMPLATE/4-support-request.md
+++ b/.github/ISSUE_TEMPLATE/4-support-request.md
@@ -1,7 +1,7 @@
 ---
 name: '❓ Support request'
 about: Questions and requests for support
-label: question
+labels: question
 ---
 
 <!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/willgm/web-crypto-storage/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] demo application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Some issue templates does not adds labels to it due incorrect use of YAML format.

## What is the new behavior?

Labels will be added correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
